### PR TITLE
[ Fix: Scenarios not whowing due to the great scale size ]

### DIFF
--- a/frontend/js/animations/utils/RouteConverter.js
+++ b/frontend/js/animations/utils/RouteConverter.js
@@ -1,6 +1,6 @@
 class RouteConverter {
     static latLngToLocal(lat, lng, centerLat, centerLng) {
-        const scale = 100000000;
+        const scale = 100000;
         const x = (lng - centerLng) * scale;
         const z = -(lat - centerLat) * scale;
         return new THREE.Vector3(x, 0, z);


### PR DESCRIPTION
- Having a very big scale made the trees, buildings and other scenario objects to not show. 
- Reduced the scale size